### PR TITLE
Bugfix: Allow matrices with a single bus entry.

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -172,7 +172,7 @@ def convert_and_aggregate(cutout, convert_func, matrix=None,
     if per_unit or return_capacity:
         assert aggregate_func is aggregate_matrix, \
             "One of `matrix`, `shapes` and `layout` must be given for `per_unit`"
-        capacity = xr.DataArray(np.asarray(matrix.sum(axis=1)).squeeze(), [index])
+        capacity = xr.DataArray(np.asarray(matrix.sum(axis=1)).reshape(-1), [index])
 
     if per_unit:
         results = (results / capacity).fillna(0.)


### PR DESCRIPTION
Previously matrices with a single entry created a 0d numpy array, causing a ValueError in xr.DataArray(...) creation.
By reshaping instead of squeezing, a 1D array is enforced.