### PR TITLE
(Refractor) Wind speed extrapolation into new module

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -357,7 +357,7 @@ def convert_wind(ds, turbine):
     """Convert wind speeds for turbine to wind energy generation."""
 
     V, POW, hub_height, P = itemgetter('V', 'POW', 'hub_height', 'P')(turbine)
-    power_curve = xr.DataArray(POW, [('wind speed', V)], name='turbine power curve')
+    power_curve = xr.DataArray(POW/P, [('wind speed', V)], name='turbine power curve')
 
     wnd_hub = windm.extrapolate_wind_speed(ds, to_height=hub_height)
 

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -32,10 +32,12 @@ from scipy.signal import fftconvolve
 from pkg_resources import resource_stream
 
 def get_windturbineconfig(turbine):
+    """Load the 'turbine'.yaml file from local disk and provide a turbine dict."""
+
     res_name = "resources/windturbine/" + turbine + ".yaml"
     turbineconf = yaml.load(resource_stream(__name__, res_name))
     V, POW, hub_height = itemgetter('V', 'POW', 'HUB_HEIGHT')(turbineconf)
-    return dict(V=V, POW=POW, hub_height=hub_height, P=max(POW))
+    return dict(V=np.array(V), POW=np.array(POW), hub_height=hub_height, P=max(POW))
 
 def get_solarpanelconfig(panel):
     res_name = "resources/solarpanel/" + panel + ".yaml"

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 3 of the
+## License, or (at your option) any later version.
+
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Renewable Energy Atlas Lite (Atlite)
+
+Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
+"""
+import xarray as xr
+import numpy as np
+
+import logging
+logger = logging.getLogger(__name__)
+
+def extrapolate_wind_speed(ds, to_height, from_height=None):
+    """Extrapolate the wind speed from a given height above ground to another.
+
+    If ds already contains a key refering to wind speeds at the desired to_height,
+    no conversion is done and the wind speeds are directly returned.
+
+    Extrapolation of the wind speed follows the logarithmic law as desribed in [1].
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing the wind speed time-series at 'from_height' with key
+        'wnd{height:d}m' and the surface orography with key 'roughness' at the
+        geographic locations of the wind speeds.
+    from_height : int
+        (Optional)
+        Height (m) from which the wind speeds are interpolated to 'to_height'.
+        If not provided, the closest height to 'to_height' is selected.
+    to_height : int
+        Height (m) to which the wind speeds are extrapolated to.
+    
+    Returns
+    -------
+    da : xarray.DataArray
+        DataArray containing the extrapolated wind speeds. Name of the DataArray
+        is 'wnd{to_height:d}'.
+
+    References
+    ----------
+    [1] Equation (2) in Andresen, G. et al (2015):
+        'Validation of Danish wind time series from a new global renewable energy atlas for energy system analysis'.
+    [2] https://en.wikipedia.org/w/index.php?title=Roughness_length&oldid=862127433, Retrieved 2019-02-15.
+    """ 
+
+    if not isinstance(to_height, int):
+        logger.warn("Integer to_height expected but got {s}."
+                    "Type casting and continuing, may lead to unexpected results.".format(s=type(to_height))
+        )
+        to_height = int(to_height)
+
+    to_name   = "wnd{h:0d}m".format(h=to_height)
+
+    # Fast lane
+    if to_name in ds:
+        return ds[to_name]
+
+    if from_height is None:
+        # Determine closest height to to_name
+        heights = np.asarray([int(s[3:-1]) for s in ds if s.startswith("wnd")])
+
+        if len(heights) == 0:
+            raise AssertionError("Wind speed is not in dataset")
+
+        from_height = heights[np.argmin(np.abs(heights-to_height))]
+    elif not isinstance(from_height, int):
+        logger.warn("Integer from_height expected but got {s}."
+                    "Trying to type caste and continue, may lead to unexpected results.".format(s=type(from_height))
+        )
+        from_height = int(from_height)
+
+    from_name = "wnd{h:0d}m".format(h=from_height)
+        
+    # Sanitise roughness for logarithm
+    # 0.0002 corresponds to open water [2]
+    ds['roughness'].values[ds['roughness'].values <= 0.0] = 0.0002
+
+    # Wind speed extrapolation
+    wnd_spd = ds[from_name] * ( np.log(to_height /ds['roughness'])
+                              / np.log(from_height/ds['roughness']))
+
+    wnd_spd.attrs.update({"long name":
+                            "extrapolated {ht:0d} m wind speed using logarithmic "
+                            "method with roughness and {hf:0d} m wind speed"
+                            "".format(ht=to_height, hf=from_height),
+                          "units" : "m s**-1"})
+
+    return wnd_spd.rename(to_name)


### PR DESCRIPTION
Logically the two actions (wind speed extrapolation and conversion) are independent steps - this is represented by the separation.
Minor: In the same go, change from numpy.interp to xarray.interp