### PR TITLE
Fix dependencies to include geopandas

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -20,3 +20,4 @@ dependencies:
   - conda-forge::rasterio
   - conda-forge::shapely
   - conda-forge::libgdal
+  - conda-forge::geopandas

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
                       'dask>=0.18.0',
                       'rasterio',
                       'shapely',
-                      'progressbar2'],
+                      'progressbar2'
+                      'geopandas'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
Geopandas became a necessary lib with the hydro module (7837f984a6dbb0c42a7adf91dc421835ab023bf0).