### PR TITLE
Provide oedb adapter for downlading wind turbine configs.

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -377,9 +377,10 @@ def wind(cutout, turbine, smooth=False, **params):
     Parameters
     ----------
     turbine : str or dict
-        Name of a turbine known by the reatlas client or a
-        turbineconfig dictionary with the keys 'hub_height' for the
+        A turbineconfig dictionary with the keys 'hub_height' for the
         hub height and 'V', 'POW' defining the power curve.
+        Alternatively a str refering to a local or remote turbine configuration
+        as accepted as accepted by atlite.resource.get_windturbineconfig().
     smooth : bool or dict
         If True smooth power curve with a gaussian kernel as
         determined for the Danish wind fleet to Delta_v = 1.27 and

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -31,6 +31,7 @@ from scipy.signal import fftconvolve
 from pkg_resources import resource_stream
 import ast
 
+from . import config
 from .wind import download_turbineconf
 
 import logging

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -59,22 +59,22 @@ def get_windturbineconfig(turbine):
             turbineconf = download_turbineconf(turbine, store_locally=False)
         else:
             turbine = {'filename':turbine, 'source':'local'}
+    elif isinstance(turbine, dict):
+        if turbine.get('source') is None:
+            logger.warning("No key 'source':'oedb' provided with the turbine dictionary."
+                           "I am assuming and adding it for now, but still nag you about it.")
+            turbine['source'] = 'oedb'
     
-    if turbine.get('source') is None:
-        logger.warning("No key 'source':'oedb' provided with the turbine dictionary."
-                       "I am assuming and adding it for now, but still nag you about it.")
-        turbine['source'] = 'oedb'
-    
-    if turbine['source'] == 'oedb':
-        turbineconf = download_turbineconf(turbine, store_locally=False)
-    elif turbine['source'] == "local":
-        res_name = os.path.join(config.windturbine_dir, turbine['filename']+".yaml")
-        res_name = construct_filepath(res_name)
+        if turbine['source'] == 'oedb':
+            turbineconf = download_turbineconf(turbine, store_locally=False)
+        elif turbine['source'] == "local":
+            res_name = os.path.join(config.windturbine_dir, turbine['filename']+".yaml")
+            res_name = construct_filepath(res_name)
 
-        with open(res_name, "r") as turbine_file:
-            turbineconf = yaml.safe_load(turbine_file)
-    else:
-        raise ValueError("Not a valid 'source'.")
+            with open(res_name, "r") as turbine_file:
+                turbineconf = yaml.safe_load(turbine_file)
+        else:
+            raise ValueError("Not a valid 'source'.")
     
     if turbineconf is None:
         raise ValueError("No matching turbine configuration found.")

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -21,6 +21,17 @@ Light-weight version of Aarhus RE Atlas for converting weather data to power sys
 """
 import xarray as xr
 import numpy as np
+import requests
+import pandas as pd
+import json
+import yaml
+import os
+
+from . import config
+from . import utils
+
+import logging
+logger = logging.getLogger(__name__)
 
 def extrapolate_wind_speed(ds, to_height, from_height=None):
     """Extrapolate the wind speed from a given height above ground to another.
@@ -90,3 +101,97 @@ def extrapolate_wind_speed(ds, to_height, from_height=None):
                           "units" : "m s**-1"})
 
     return wnd_spd.rename(to_name)
+
+def download_turbineconf(requested_turbine=None):
+    """Download a windturbine configuration from the OEDB database.
+    
+    Download the configuration of a windturbine model from the OEDB database
+    into the local 'windturbine_dir'.
+    The OEDB database can be viewed here:
+    https://openenergy-platform.org/dataedit/view/supply/turbine_library
+    (2019-07-22)
+    Only one turbine configuration is downloaded at a time, if the 
+    search parameters yield an ambigious result, not data is downloaded.
+    
+    Parameters
+    ----------
+    requested_turbine : dict
+        Search parameters, either provide the turbine model id (takes priority)
+        or a manufacturer and turbine name, e.g. the following are identical:
+        {'id':10}, {'id':10, 'manufacturer':'Unknown', name:'E-53/800'},
+        {'manufacturer':'Enercon', name:'E-53/800'}
+        
+    Returns
+    -------
+    turbineconf : dict
+        The turbine configuration downloaded and stored is also returned as a dict.
+        Has the same format as returned by 'atlite.ressource.get_turbineconf(name)'.
+    """
+    
+    # Get the turbine list
+    oedb_url = 'https://openenergy-platform.org/api/v0/schema/supply/tables/turbine_library/rows'
+    result = requests.get(oedb_url)
+
+    # Convert JSON to dataframe for easier filtering
+    # Only consider turbines with power curves available
+    df = pd.DataFrame.from_dict(result.json())
+    df = df[df.has_power_curve]
+
+    if requested_turbine.get('id'):
+        logger.info("Searching turbine power curve in OEDB database using id "
+                    "'{id}'".format(id=requested_turbine['id'])
+                   )
+        ds = df[df.id == requested_turbine['id']]
+        
+    else:
+        if not isinstance(requested_turbine.get('name'),str) or
+           not isinstance(requested_turbine.get('manufacturer'),str):
+            
+            logger.error("'name' and 'manufacturer' must be provided. "
+                         "Alternatively provide a turbine id from OEDB.")
+            return None
+        logger.info("Searching turbine power curve in OEDB database using "
+                    "manufacturer '{m}' and name '{n}'."
+                    "".format(m=requested_turbine['manufacturer'],
+                              n=requested_turbine['name']))
+            
+        ds = df[df.name == requested_turbine['name']]
+        ds = ds[ds.manufacturer == requested_turbine['manufacturer']]
+
+    if len(ds) < 1 :
+        logger.info("No turbine found for {rt}.".format(rt=requested_turbine))
+    elif len(ds) > 2 :
+        logger.info("Provided information corresponds to more than one turbine. "
+                    "Provide id to unambigious lookup. {rt}."
+                    "".format(rt=requested_turbine))
+    elif len(ds) == 1:
+        # Convert to series for simpliticty
+        ds = ds.iloc[0]
+
+    # convert power from kW to MW
+    power = np.array(json.loads(ds.power_curve_values)) / 1e3
+
+    turbineconf = {
+        "name": ds['name'].strip(),
+        "manufacturer": ds.manufacturer.strip(),
+        "source": "Original: {origin}. "
+                  "Via OEDB {secondary}".format(origin=ds.source, secondary=oedb_url),
+        "HUB_HEIGHT": ds.hub_height.strip(),
+        "V": json.loads(ds.power_curve_wind_speeds),
+        "POW": power.tolist(),
+    }
+
+    filename = "{m}_{n}.yaml".format(m=turbineconf['manufacturer'],
+                                     n=turbineconf['name'])
+    filename = filename.replace("/","_")
+    filename = filename.replace(" ","_")
+    filepath = utils.construct_filepath(os.path.join(config.windturbine_dir, filename))
+
+    with open(filepath, 'w') as turbine_file:
+        yaml.dump(turbineconf, turbine_file)
+        
+    logger.info("Turbine configuration downloaded to '{fp}'.".format(fp=filepath))
+    if ";" in turbineconf['HUB_HEIGHT']:
+        logger.info("Multiple HUB_HEIGHTS in dataset. Manual clean-up required.")
+
+    return turbineconf

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -156,8 +156,8 @@ def download_turbineconf(turbine, store_locally=True):
 
         # 'turbine' is a name or combi of manufacturer + name
         # Matches e.g. "TurbineName", "Manu1/Manu2_Turbine/number", "Man. Turb." 
-        # Split on white-spaces and underscore.
-        m = re.split("[\s|_]+",s)
+        # Split on white-spaces, underscore and pipes.
+        m = re.split("[\s|_]+",s, maxsplit=1)
         if m and parsed is False:
             if len(m) == 1:
                 turbine.setdefault('name', m[0])

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -27,7 +27,6 @@ import json
 import yaml
 import os
 
-from . import config
 from . import utils
 
 import logging
@@ -135,8 +134,8 @@ def download_turbineconf(turbine=None, store_locally=True):
         # Get the turbine list
         OEDB_URL = 'https://openenergy-platform.org/api/v0/schema/supply/tables/turbine_library/rows'
         result = requests.get(OEDB_URL)
-    except requests.exceptions.RequestException:
-        logger.exception('Exception encountered when trying to connect to OEDB.')
+    except requests.exceptions.RequestException as e:
+        logger.info(f"Connection to OEDB failed with:\n\n{str(e)}")
         return None
 
     # Convert JSON to dataframe for easier filtering
@@ -147,7 +146,7 @@ def download_turbineconf(turbine=None, store_locally=True):
     # Check which information is provided for lookup and proceed accordingly
     if turbine.get('id'):
         logger.info(f"Searching for turbine in OEDB with id '{turbine['id']}'.")
-        ds = df[df.id == turbine['id']]
+        ds = df[df.id == int(turbine['id'])]
         
     else:
         if not all({isinstance(v, str)

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -27,6 +27,7 @@ import json
 import yaml
 import os
 
+from . import config
 from . import utils
 
 import logging


### PR DESCRIPTION
As stated in #21 , this change provides an adapter for downloading into `resources/windturbine` (more precisely `atlite.config.windturbine_dir`) and using the data from OEDB.

```
def download_turbineconf(requested_turbine=None):
    """Download a windturbine configuration from the OEDB database.
    
    Download the configuration of a windturbine model from the OEDB database
    into the local 'windturbine_dir'.
    The OEDB database can be viewed here:
    https://openenergy-platform.org/dataedit/view/supply/turbine_library
    (2019-07-22)
    Only one turbine configuration is downloaded at a time, if the 
    search parameters yield an ambigious result, not data is downloaded.
    
    Parameters
    ----------
    requested_turbine : dict
        Search parameters, either provide the turbine model id (takes priority)
        or a manufacturer and turbine name, e.g. the following are identical:
        {'id':10}, {'id':10, 'manufacturer':'Unknown', name:'E-53/800'},
        {'manufacturer':'Enercon', name:'E-53/800'}
        
    Returns
    -------
    turbineconf : dict
        The turbine configuration downloaded and stored is also returned as a dict.
        Has the same format as returned by 'atlite.ressource.get_turbineconf(name)'.
    """
```

*Depends on minor changes introduced in #23 .*

