### PR TITLE
[v0.2] Fix PermissionError (Windows) (+ minor: Remove <3.0 artifacts)

### DIFF
--- a/atlite/__init__.py
+++ b/atlite/__init__.py
@@ -20,9 +20,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-
-from __future__ import absolute_import
-
 from .cutout import Cutout
 from .gis import compute_indicatormatrix, regrid
 

--- a/atlite/aggregate.py
+++ b/atlite/aggregate.py
@@ -20,8 +20,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import xarray as xr
 import dask
 

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -22,8 +22,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import xarray as xr
 import numpy as np
 import pandas as pd

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -20,8 +20,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import xarray as xr
 import numpy as np
 import os, sys

--- a/atlite/datasets/__init__.py
+++ b/atlite/datasets/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from . import era5
 # from . import cordex, ncep, era5, sarah

--- a/atlite/datasets/cordex.py
+++ b/atlite/datasets/cordex.py
@@ -21,8 +21,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import pandas as pd
 import numpy as np
 import xarray as xr

--- a/atlite/datasets/ncep.py
+++ b/atlite/datasets/ncep.py
@@ -20,8 +20,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import pandas as pd
 import numpy as np
 import xarray as xr

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -20,8 +20,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import pandas as pd
 import numpy as np
 import xarray as xr

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -19,8 +19,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import numpy as np
 import pandas as pd
 import xarray as xr

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from operator import itemgetter
 
 import numpy as np

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -21,8 +21,6 @@ Renewable Energy Atlas Lite (Atlite)
 Light-weight version of Aarhus RE Atlas for converting weather data to power systems data
 """
 
-from __future__ import absolute_import
-
 import os
 import yaml
 from operator import itemgetter


### PR DESCRIPTION
This PR fixes #22 and removes some artifacty from support of Python versions <3.0, where many modules contained:

```
from __future__ import absolute_import
```