### PR TITLE
V0.2 fix ast._NUM_TYPES usage.

### DIFF
--- a/atlite/data.py
+++ b/atlite/data.py
@@ -43,7 +43,7 @@ def literal_eval_creation_parameters(node_or_string):
             return node.value
         elif isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
             operand = _convert(node.operand)
-            if isinstance(operand, ast._NUM_TYPES):
+            if isinstance(operand, (int, float, complex)):
                 if isinstance(node.op, ast.UAdd):
                     return + operand
                 else:


### PR DESCRIPTION
Internal variable. No longer available in Python 3.7
see here:
https://github.com/python/cpython/commit/d8ac4d1d5ac256ebf3d8d38c226049abec82a2a0?diff=unified